### PR TITLE
Support non load/store components

### DIFF
--- a/src/main/scala/onera/pmlanalyzer/pml/model/hardware/BaseHardwareNodeBuilder.scala
+++ b/src/main/scala/onera/pmlanalyzer/pml/model/hardware/BaseHardwareNodeBuilder.scala
@@ -150,4 +150,19 @@ trait BaseHardwareNodeBuilder[T <: Hardware] extends PMLNodeBuilder[T] {
   def apply(name: Symbol)(implicit p: ProvideRelation[Hardware, Service],
                           owner: Owner): T =
     apply(name, Set.empty, true)
+
+
+  /**
+    * A physical component can be defined only its name, the services will be defined by default
+    *
+    * @group publicConstructor
+    * @param name  the physical component name
+    * @param withDefaultServices add default Load/Store services on creation
+    * @param p     implicitly retrieved relation linking components to their provided services
+    * @param owner implicitly retrieved name of the platform
+    * @return the physical component
+    */
+  def apply(name: Symbol, withDefaultServices: Boolean)(implicit p: ProvideRelation[Hardware, Service],
+                          owner: Owner): T =
+    apply(name, Set.empty, withDefaultServices)
 }

--- a/src/test/scala/onera/pmlanalyzer/pml/model/hardware/HardwareTest.scala
+++ b/src/test/scala/onera/pmlanalyzer/pml/model/hardware/HardwareTest.scala
@@ -26,4 +26,16 @@ class HardwareTest extends AnyFlatSpec with should.Matchers {
       h.services.size shouldBe 2
     }
   }
+
+  it should "have no services when specified" in {
+    val t: Target = Target(withDefaultServices=false)
+    val s: SimpleTransporter = SimpleTransporter(withDefaultServices=false)
+    val i: Initiator = Initiator(withDefaultServices=false)
+    val v: Virtualizer = Virtualizer(withDefaultServices=false)
+
+    for (h <- List(t, s, i, v)) {
+      h.services shouldBe empty
+    }
+  }
+
 }

--- a/src/test/scala/onera/pmlanalyzer/pml/model/hardware/HardwareTest.scala
+++ b/src/test/scala/onera/pmlanalyzer/pml/model/hardware/HardwareTest.scala
@@ -39,18 +39,18 @@ class HardwareTest extends AnyFlatSpec with should.Matchers {
   }
 
   it should "have only specified services when specified" in {
-    val t: Target = Target(Set(Load("a"), Load("b")), false)
+    val t: Target = Target(Set(Load("a"), Load("b")), withDefaultServices = false)
     t.services.size shouldEqual 2
     exactly(2, t.services) shouldBe a [Load]
 
-    val s = Target(Set(Store("a")), false)
+    val s = Target(Set(Store("a")), withDefaultServices = false)
     s.services.size shouldEqual 1
     exactly(1, s.services) shouldBe a[Store]
 
-    val i = Target(Set.empty, false)
+    val i = Target(Set.empty, withDefaultServices = false)
     i.services.size shouldEqual 0
 
-    val j = Target(Symbol("j"), false)
+    val j = Target(Symbol("j"), withDefaultServices = false)
     j.services.size shouldEqual 0
   }
 

--- a/src/test/scala/onera/pmlanalyzer/pml/model/hardware/HardwareTest.scala
+++ b/src/test/scala/onera/pmlanalyzer/pml/model/hardware/HardwareTest.scala
@@ -1,0 +1,29 @@
+package onera.pmlanalyzer.pml.model.hardware
+
+import onera.pmlanalyzer.pml.model.hardware.*
+import onera.pmlanalyzer.pml.model.service.{Load, Store}
+import onera.pmlanalyzer.pml.operators.*
+import sourcecode.Name
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should
+
+class HardwareTest extends AnyFlatSpec with should.Matchers {
+
+  /* Create a default platform to act as a container for components. */
+  object PlatformFixture extends Platform(Symbol("fixture"))
+
+  import PlatformFixture.*
+
+  "A Hardware" should "have default services" in {
+    val t: Target = Target()
+    val s: SimpleTransporter = SimpleTransporter()
+    val i: Initiator = Initiator()
+    val v: Virtualizer = Virtualizer()
+
+    for (h <- List(t, s, i, v)) {
+      exactly(1, h.services) shouldBe a [Load]
+      exactly(1, h.services) shouldBe a [Store]
+      h.services.size shouldBe 2
+    }
+  }
+}

--- a/src/test/scala/onera/pmlanalyzer/pml/model/hardware/HardwareTest.scala
+++ b/src/test/scala/onera/pmlanalyzer/pml/model/hardware/HardwareTest.scala
@@ -28,14 +28,27 @@ class HardwareTest extends AnyFlatSpec with should.Matchers {
   }
 
   it should "have no services when specified" in {
-    val t: Target = Target(withDefaultServices=false)
-    val s: SimpleTransporter = SimpleTransporter(withDefaultServices=false)
-    val i: Initiator = Initiator(withDefaultServices=false)
-    val v: Virtualizer = Virtualizer(withDefaultServices=false)
+    val t: Target = Target(withDefaultServices = false)
+    val s: SimpleTransporter = SimpleTransporter(withDefaultServices = false)
+    val i: Initiator = Initiator(withDefaultServices = false)
+    val v: Virtualizer = Virtualizer(withDefaultServices = false)
 
     for (h <- List(t, s, i, v)) {
       h.services shouldBe empty
     }
+  }
+
+  it should "have only specified services when specified" in {
+    val t: Target = Target(Set(Load("a"), Load("b")), false)
+    t.services.size shouldEqual 2
+    exactly(2, t.services) shouldBe a [Load]
+
+    val s = Target(Set(Store("a")), false)
+    s.services.size shouldEqual 1
+    exactly(1, s.services) shouldBe a[Store]
+
+    val i = Target(Set.empty, false)
+    i.services.size shouldEqual 0
   }
 
 }

--- a/src/test/scala/onera/pmlanalyzer/pml/model/hardware/HardwareTest.scala
+++ b/src/test/scala/onera/pmlanalyzer/pml/model/hardware/HardwareTest.scala
@@ -49,6 +49,9 @@ class HardwareTest extends AnyFlatSpec with should.Matchers {
 
     val i = Target(Set.empty, false)
     i.services.size shouldEqual 0
+
+    val j = Target(Symbol("j"), false)
+    j.services.size shouldEqual 0
   }
 
 }


### PR DESCRIPTION
## Description

Add a flag to support the creation of hardware components without the default Load and Store services.

Help would be appreciated for:
- test case generation: the current tests use ad-hoc definitions instead of neat generators
- code quality: a shorter flag name might be better, unclear on Scala naming conventions.

## What type of pull request is this? (check all applicable)

- [x] Feature
- [ ] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [x] Test
- [x] Build
- [ ] CI
- [ ] Chore (Release)
- [ ] Revert

## Related Tickets & Documents

Closes #13 

## Added tests?

- [x] yes
- [ ] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] README.md
- [x] doc
- [ ] no documentation needed

## Do we need to update pml analyzer version?

- [ ] no
- [ ] the pull request is only a bug fix, need a bug fix version update
- [x] the pull request add new features and ensures retro-compatibility, need a feature addition version update
- [ ] the pull request is not ensuring retro-capatibility, need a major version update 
- [ ] not sure, I need help

## Is this new version should be released as soon as possible? 

- [ ] yes
- [x] no
- [ ] not sure, I need help
