### PR TITLE
Fix dynamic library loading on successive analyses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# PML
+/analysis/
+
+# sbt
+# https://www.scala-sbt.org/release/docs/Directories.html
+/project/target/
+/project/project/
+/target/
+
+# IDE
+/.idea/

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,6 @@ val scopt = "com.github.scopt" %% "scopt" % "4.1.0"
 val scalactic = "org.scalactic" %% "scalactic" % "3.2.15"
 val scalatest = "org.scalatest" %% "scalatest" % "3.2.15" % "test"
 val scalaplus = "org.scalatestplus" %% "scalacheck-1-15" % "3.2.11.0" % "test"
-
 lazy val modelCode = taskKey[Seq[(String,File)]]("files to be embedded in docker")
 
 lazy val dockerProxySetting = (
@@ -123,3 +122,9 @@ lazy val PMLAnalyzer = (project in file("."))
   .settings(
     name := "pml_analyzer")
 
+
+// Fork a new JVM on every sbt run task
+// Fixes an issue with the classloader complaining that the Monosat library is
+// "already loaded in another classloader" on successive runs of the analysis
+// in the same sbt instance.
+fork := true


### PR DESCRIPTION
## Description

Fixes #9, forcing sbt run and test commands to spawn a new JVM (and thus load the monosat libraries in a clean environment).
Also adds a `.gitignore` for sbt and PML files.

## What type of pull request is this? (check all applicable)

- [ ] Feature
- [x] Bug Fix
- [ ] Documentation Update
- [ ] Style
- [ ] Code Refactor
- [ ] Performance Improvements
- [ ] Test
- [ ] Build
- [ ] CI
- [ ] Chore (Release)
- [ ] Revert

## Related Tickets & Documents

Fixes #9 

## Added tests?

- [ ] yes
- [x] no, because they aren't needed
- [ ] no, because I need help

## Added to documentation?

- [ ] README.md
- [ ] doc
- [x] no documentation needed

## Do we need to update pml analyzer version?

- [ ] no
- [x] the pull request is only a bug fix, need a bug fix version update
- [ ] the pull request add new features and ensures retro-compatibility, need a feature addition version update
- [ ] the pull request is not ensuring retro-capatibility, need a major version update 
- [ ] not sure, I need help

## Is this new version should be released as soon as possible? 

- [ ] yes
- [ ] no
- [x] not sure, I need help
